### PR TITLE
Update user-manual.md

### DIFF
--- a/user-manual.md
+++ b/user-manual.md
@@ -335,7 +335,7 @@ bounds.  For instance:
       (cond (< v 2) "baby"
             (< v 10) "child"
             (< v 20) "teenager"
-            "adult")
+            "adult"))
 ```
 
 Flatline provides a shortcut for the above expression via its


### PR DESCRIPTION
The expression:

(let (v (f "age"))
      (cond (< v 2) "baby"
            (< v 10) "child"
            (< v 20) "teenager"
            "adult"))

wasn't closed properly